### PR TITLE
bagpipes.flow(..) - support last argument - `callback(err,ctx)`

### DIFF
--- a/lib/bagpipes.js
+++ b/lib/bagpipes.js
@@ -54,7 +54,7 @@ Bagpipes.prototype.play = function play(pipe, context, done) {
 
   if (typeof context === 'function') {
       done = context;
-      context = null;
+      context = undefined;
   }
   assert(typeof context === 'undefined' || typeof context === 'object', 'context must be an object');
   assert(typeof done === 'undefined' || typeof done === 'function' && done.length == 2, 'end-callback must be a function that expects 2 argument - error, and the context');
@@ -65,7 +65,7 @@ Bagpipes.prototype.play = function play(pipe, context, done) {
   pw.fit(function(context, next) { pipe.siphon(context, next); });
   if (context._finish) { pw.fit(context._finish); }
   if (done) { 
-      pw.fit( function done_success(ctx) { done(null, ctx) } );
+      pw.fit( function done_success(ctx, _) { done(null, ctx) } );
       pw.fault( function done_fault(ctx, err) { done (err, ctx) } );
   }
   

--- a/lib/bagpipes.js
+++ b/lib/bagpipes.js
@@ -50,14 +50,25 @@ Bagpipes.prototype.getPipe = function getPipe(pipeName, pipeDef) {
   return this.pipes[pipeName] = this.createPipe(pipeDef);
 };
 
-Bagpipes.prototype.play = function play(pipe, context) {
+Bagpipes.prototype.play = function play(pipe, context, done) {
 
+  if (typeof context === 'function') {
+      done = context;
+      context = null;
+  }
   assert(typeof context === 'undefined' || typeof context === 'object', 'context must be an object');
+  assert(typeof done === 'undefined' || typeof done === 'function' && done.length == 2, 'end-callback must be a function that expects 2 argument - error, and the context');
+  
   if (!context) { context = {}; }
 
   var pw = pipeworks();
   pw.fit(function(context, next) { pipe.siphon(context, next); });
   if (context._finish) { pw.fit(context._finish); }
+  if (done) { 
+      pw.fit( function done_success(ctx) { done(null, ctx) } );
+      pw.fault( function done_fault(ctx, err) { done (err, ctx) } );
+  }
+  
   pw.flow(context);
 };
 

--- a/test/bagpipes.js
+++ b/test/bagpipes.js
@@ -91,7 +91,7 @@ describe('bagpipes', function() {
     });
     
     describe('and the pipe flow fails', function() {
-      it('should pass context to the done', function(done){
+      it('should pass error and context to the done', function(done){
         var userFittingsDirs = [ path.resolve(__dirname, './fixtures/fittings') ];
         var pipe = [ 'test', 'test', 'emit', 'test', 'error' ];
         var bagpipes = Bagpipes.create({ pipe: pipe }, { userFittingsDirs: userFittingsDirs });

--- a/test/bagpipes.js
+++ b/test/bagpipes.js
@@ -75,5 +75,33 @@ describe('bagpipes', function() {
     context.error.should.be.an.Error;
     context.output.should.eql('test');
     done();
+  });
+  describe('when provided with a done(err,ctx) callback', function() {
+    describe('and the pipe flow succeeds', function() {
+      it('should pass context to the done', function(done){
+        var userFittingsDirs = [ path.resolve(__dirname, './fixtures/fittings') ];
+        var pipe = [ 'test', 'test', 'emit', 'test' ];
+        var bagpipes = Bagpipes.create({ pipe: pipe }, { userFittingsDirs: userFittingsDirs });
+        var context = {};
+        bagpipes.play(bagpipes.getPipe('pipe'), context, function(err, context) { 
+          context.output.should.eql('test');
+          done(err);
+        });
+      })
+    });
+    
+    describe('and the pipe flow fails', function() {
+      it('should pass context to the done', function(done){
+        var userFittingsDirs = [ path.resolve(__dirname, './fixtures/fittings') ];
+        var pipe = [ 'test', 'test', 'emit', 'test', 'error' ];
+        var bagpipes = Bagpipes.create({ pipe: pipe }, { userFittingsDirs: userFittingsDirs });
+        var context = {};
+        bagpipes.play(bagpipes.getPipe('pipe'), context, function(err, context) {
+          should(err).be.an.Error;
+          context.output.should.eql('test');
+          done()
+        });
+      })
+    })    
   })
 });


### PR DESCRIPTION
Hi.

This PR is not ready - I need to **_discuss**_ with you few points first.

I created this branch to create a PR from it, I cloned it and I wanted to add tests.

Then I saw this inside, which completely confused me:

```
  it('should throw errors if no onError handler', function(done) {
    var userFittingsDirs = [ path.resolve(__dirname, './fixtures/fittings') ];
    var pipe = [ 'error' ];
    var bagpipes = Bagpipes.create({ pipe: pipe }, { userFittingsDirs: userFittingsDirs });
    var context = {};
    (function() {
      bagpipes.play(bagpipes.getPipe('pipe'), context)
    }).should.throw.error;
    done();
  });
```

The part that confused me is `should.throw.error`. IMHO - there's trouble.

The troubles can be tested if you change `test/fixtures/fittings/emit.js`
from:

```
'use strict';

module.exports = function create() {
  return function emit(context, cb) {
    cb(null, 'test');
  }
};
```

to:

```
'use strict';

module.exports = function create() {
  return function emit(context, cb) {
    process.nextTick(function() {
      cb(null, 'test');
    })
  }
};
```

In this case - the tests that come with the repo fail, which suggests that as tests they do not represent real-world usage, and that's pitty 😞 

What would you propose?
