### PR TITLE
Fix incompatibility with jest

### DIFF
--- a/lib/fittingTypes/user.js
+++ b/lib/fittingTypes/user.js
@@ -21,7 +21,8 @@ module.exports = function createFitting(pipes, fittingDef) {
       return fitting;
     } catch (err) {
       if (err.code !== 'MODULE_NOT_FOUND') { throw err; }
-      var split = err.message.split(path.sep);
+      var pathFromError = err.message.match(/'.*?'/)[0];
+      var split = pathFromError.split(path.sep);
       if (split[split.length - 1] === fittingDef.name + "'") {
         debug('no user fitting %s in %s', fittingDef.name, dir);
       } else {


### PR DESCRIPTION
When using Jest as testrunner, error messages while loading fittings look different:

`Error: Cannot find module '../src/service/fittings/swagger_validator'`

With Jest:

`Cannot find module '/Users/PD/work-local/AppHub/crashes-api/src/service/fittings/swagger_validator' from 'user.js'`

Note the `from 'user.js'` at the end that breaks a check. This PR fixes that.