### PR TITLE
fix bagpipies for jest

### DIFF
--- a/lib/fittingTypes/user.js
+++ b/lib/fittingTypes/user.js
@@ -22,8 +22,8 @@ module.exports = function createFitting(pipes, fittingDef) {
     } catch (err) {
       if (err.code !== 'MODULE_NOT_FOUND') { throw err; }
       var pathFromError = err.message.match(/'.*?'/)[0];
-      var split = pathFromError.split(path.sep);
-      if (split[split.length - 1] === fittingDef.name + "'") {
+      var fittingIndex = err.message.indexOf(fittingDef.name);
+      if (err.message[fittingIndex - 1] === path.sep && err.message[fittingDef.name.length] !== path.sep) {
         debug('no user fitting %s in %s', fittingDef.name, dir);
       } else {
         throw err;


### PR DESCRIPTION
jest tests dont work with bagpipes. the error message returned by jest's resolver (they override the standard nodejs one) is not the same as nodejs's

this simple fix makes everything work again