### PR TITLE
Add support for default exports

### DIFF
--- a/lib/fittingTypes/user.js
+++ b/lib/fittingTypes/user.js
@@ -16,6 +16,10 @@ module.exports = function createFitting(pipes, fittingDef) {
     var modulePath = path.resolve(dir, fittingDef.name);
     try {
       var module = require(modulePath);
+      if (module.default && typeof module.default === 'function') {
+        module = module.default;
+      }
+
       var fitting = module(fittingDef, pipes);
       debug('loaded user fitting %s from %s', fittingDef.name, dir);
       return fitting;


### PR DESCRIPTION
## What
User fittings transpiled by babel using `export default` do not work with bagpipes. Add a check to detect if a default attribute exists within `module` to support this use-case.