### PR TITLE
Add feature to look for pre-initialized fittings modules 

### DIFF
--- a/lib/fittingTypes/user.js
+++ b/lib/fittingTypes/user.js
@@ -8,13 +8,14 @@ var assert = require('assert');
 module.exports = function createFitting(pipes, fittingDef) {
 
   assert(fittingDef.name, util.format('name is required on fitting: %j', fittingDef));
-  if (!pipes.config.userFittingsDirs) { return null; }
 
   // If there is pre-initialized fittings modules available, return these
   if (pipes.config.fittings && pipes.config.fittings[fittingDef.name]) {
       debug('loaded user fitting %s from pre-initialized modules', fittingDef.name);
       return pipes.config.fittings[fittingDef.name](fittingDef, pipes);
   }
+
+  if (!pipes.config.userFittingsDirs) { return null; }
 
   for (var i = 0; i < pipes.config.userFittingsDirs.length; i++) {
     var dir = pipes.config.userFittingsDirs[i];

--- a/lib/fittingTypes/user.js
+++ b/lib/fittingTypes/user.js
@@ -10,6 +10,12 @@ module.exports = function createFitting(pipes, fittingDef) {
   assert(fittingDef.name, util.format('name is required on fitting: %j', fittingDef));
   if (!pipes.config.userFittingsDirs) { return null; }
 
+  // If there is pre-initialized fittings modules available, return these
+  if (pipes.config.fittings && pipes.config.fittings[fittingDef.name]) {
+      debug('loaded user fitting %s from pre-initialized modules', fittingDef.name);
+      return pipes.config.fittings[fittingDef.name](fittingDef, pipes);
+  }
+
   for (var i = 0; i < pipes.config.userFittingsDirs.length; i++) {
     var dir = pipes.config.userFittingsDirs[i];
 

--- a/test/bagpipes.js
+++ b/test/bagpipes.js
@@ -45,6 +45,19 @@ describe('bagpipes', function() {
     done();
   });
 
+  it('should load pre-initialized fittings', function(done) {
+    var emitFitting = function create() {
+      return function (context, cb) {
+        cb(null, 'pre-initialized');
+    }};
+    var pipe = [ 'emit' ];
+    var bagpipes = Bagpipes.create({ pipe: pipe }, {fittings: { emit: emitFitting}});
+    var context = {};
+    bagpipes.play(bagpipes.getPipe('pipe'), context);
+    context.output.should.eql('pre-initialized');
+    done();
+  });  
+
   it('should allow user fittings to override system fittings', function(done) {
     var userFittingsDirs = [ path.resolve(__dirname, './fixtures/fittings') ];
     var pipe = [ 'test' ];


### PR DESCRIPTION
Sometimes its required to pre-initialize some fittings that may require some specific dependency injection and any custom initialization flow. 

This patch will help to pass such fitting modules to be passed directly to pipes config. 