### PR TITLE
Update dependencies to address vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.0.0",
     "should": "^7.1.0",
-    "supertest": "^1.1.0"
+    "supertest": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "coveralls": "^2.11.4",
     "istanbul": "^0.4.0",
-    "mocha": "^2.3.0",
+    "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.0.0",
     "should": "^7.1.0",
     "supertest": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pipeworks": "^1.3.0"
   },
   "devDependencies": {
-    "coveralls": "^2.11.4",
+    "coveralls": "^3.0.2",
     "istanbul": "^0.4.0",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "^1.4.2",
     "debug": "^2.1.2",
     "jspath": "^0.3.1",
-    "lodash": "^3.5.0",
+    "lodash": "^4.17.10",
     "machinepack-http": "^2.3.0",
     "mustache": "^2.1.3",
     "pipeworks": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "^2.1.2",
     "jspath": "^0.3.1",
     "lodash": "^4.17.10",
-    "machinepack-http": "^2.3.0",
+    "machinepack-http": "^6.0.1",
     "mustache": "^2.1.3",
     "pipeworks": "^1.3.0"
   },


### PR DESCRIPTION
Not gonna lie, I'm amazed that all the tests still pass with this many semver major dependency updates.

Updating the vulnerabilities listed here may help address upstream reports for [swagger-express](https://github.com/apigee-127/swagger-express)