### PR TITLE
remove pipe config handling from http fitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,12 +350,8 @@ Select the values of an object as an array.
 
 Make a call to a URL.
 
-config keys:
-
-* baseUrl (optional)
-
 input keys:
-
+* baseUrl (optional)
 * url    (optional: default = context.output)
 * method (optional: default = get) (get, post, put, delete, patch, etc.)
 * params (optional) key/value pairs

--- a/lib/fittings/http.js
+++ b/lib/fittings/http.js
@@ -7,13 +7,11 @@ var Http = require('machinepack-http');
 // defaults output -> url
 module.exports = function create(fittingDef) {
 
-  var config = _.extend({ baseUrl: '' }, fittingDef.config);
-
   return function http(context, cb) {
 
     var input = (typeof context.input === 'string') ? { url: context.input } : context.input;
 
-    var options = _.extend({ url: context.output }, input, config);
+    var options = _.extend({ url: context.output }, input);
 
     Http.sendHttpRequest(options, cb);
   }


### PR DESCRIPTION
### Http fitting - baseUrl

#### Purpose
Write a pipe that uses http fitting and baseUrl comes from environment.

#### Issues
Based on the readme baseUrl need to be set in pipe config where it can have only static value (e.g. baseUrl: http://example.com). When baseUrl is moved to pipe input, it can have dynamic value from context (e.g. baseUrl: .environments.EXAMPLE_BASE_URL), but the http fitting overwrites this with default value or with value from config.baseUrl.

```
var config = _.extend({ baseUrl: '' }, fittingDef.config);
```
This line set a default value for baseUrl. It's unnecessary because **machinepack-http:2.4.0** checks baseUrl and if it's undefined or null then set an empty string and validate url param (it has to be a valid url if baseUrl undefined). (*machinepack-http/machines/send-http-request.js:128 - 148*)

```
var options = _.extend({ url: context.output }, input, config);
```
If baseUrl is set in pipe input and config.baseUrl is set or not set then the previous line set a default or static value for baseUrl in config and after that this line overwrites input.baseUrl with the default or static value.

#### Solution
Remove pipe config handling from http fitting and set baseUrl in pipe input.
