### PR TITLE
update machinepack-http version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "^2.1.2",
     "jspath": "^0.3.1",
     "lodash": "^4.17.10",
-    "machinepack-http": "^6.0.1",
+    "machinepack-http": "^7.0.3",
     "mustache": "^2.1.3",
     "pipeworks": "^1.3.0"
   },


### PR DESCRIPTION
Update machinepack-http version to address security audit warnings. 

I upgraded it to 7.0.3 which addressed the security issues, not the latest 8.0.0 because I was unable to find any release notes on what breaking changes are in machinepack-http. The tests pass also on 8.0.0.